### PR TITLE
[Feature] Link - Add attachment type support

### DIFF
--- a/packages/components/src/components/Link/Link.stories.tsx
+++ b/packages/components/src/components/Link/Link.stories.tsx
@@ -86,6 +86,15 @@ export const Inline: Story = {
   },
 }
 
+export const _Attachment: Story = {
+  args: {
+    text: 'Attachment.pdf',
+    onPress: undefined, // Storybook sends a truthy function shell otherwise
+    type: 'attachment',
+    a11yValue: { index: 2, total: 5 },
+  },
+}
+
 export const _Calendar: Story = {
   args: {
     text: 'Add to calendar',

--- a/packages/components/src/components/Link/Link.stories.tsx
+++ b/packages/components/src/components/Link/Link.stories.tsx
@@ -55,37 +55,6 @@ export const DefaultWithIcon: Story = {
   },
 }
 
-const paragraphText: LinkProps['paragraphText'] = [
-  // @ts-ignore: TS being wrong and thinking all should be LinkProps and none normalText
-  { text: 'A sentence may include a ' },
-  {
-    text: 'link that opens in the app',
-    type: 'custom',
-    onPress: () => {
-      null
-    },
-    a11yLabel: 'a11y override',
-  },
-  // @ts-ignore: TS being wrong and thinking all should be LinkProps and none normalText
-  { text: ' or a ' },
-  {
-    text: 'link that opens in an external app',
-    type: 'url',
-    url: 'https://department-of-veterans-affairs.github.io/va-mobile-app/design/intro',
-  },
-  // @ts-ignore: TS being wrong and thinking all should be LinkProps and none normalText
-  { text: '.' },
-]
-
-export const Inline: Story = {
-  args: {
-    text: '',
-    onPress: undefined, // Storybook sends a truthy function shell otherwise
-    type: 'inline',
-    paragraphText: paragraphText,
-  },
-}
-
 export const _Attachment: Story = {
   args: {
     text: 'Attachment.pdf',


### PR DESCRIPTION
<!-- PR title naming convention:
'[Issue type] Brief summary of issue suitable for changelog or copy/paste issue title',
where Issue type = bug, feature, spike, CU (code upkeep), etc.-->

<!-- Preferred branch naming convention:
'[Issue type]/[Issue #]-[Your name]-[Summary of issue]',
where Issue type = bug, feature, spike, CU (code upkeep), etc.-->

<!-- Update w/ ticket number to cross-repo link PR and ticket; ZenHub URL does not work
**[Ticket # ](https://github.com/department-of-veterans-affairs/va-mobile-app/issues/# )** -->

## Description of Change
<!-- Describe the change and context with which it was made beyond ACs unless straightforward.
Consider:
 - What is relevant to code reviewer(s) and not in the ticket?
 - What context may be relevant to a future dev or you in 6 months about this PR?
 - Did the course of work lead to notable dead ends? If so, why didn't they pan out?
 - Did the change add new dependencies? Why?
 - Were there important sources to link? Examples: an open bug with a dependency project, an article of someone else solving the same problem that was partially or wholly copied, external documentation relevant to solution -->

- Added attachment type support to Link:
   - Prefills PaperClip icon
   - Required onPress logic from app
   - Includes a11yValue prop to support "[position #] of [total #]" list logic (or whatever custom string an app wants to pass if having preferred language for lists)
- Removed inline type support and related cleanup per team decision to not move forward with it for now

### Screenshots/Video
<!-- Add screenshots or video as needed; before/after recommended if appropriate. 
Convenience side-by-side formatting:
Before/after: <img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" />
Accordion before/after: <details><summary>Before/after</summary><img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" /></details>
-->
iOS:

https://github.com/department-of-veterans-affairs/va-mobile-library/assets/8690976/ca8c3032-8997-4c22-9f4a-82df4a5b5d3f

Android:

https://github.com/department-of-veterans-affairs/va-mobile-library/assets/8690976/1bd937b6-b27d-4ed8-be21-8cd459079e6c

## Testing
<!-- Describe testing conducted to validate changes.
Consider highlighting:
- What testing was not explicitly done and may be relevant for QA? 
- Edge cases validated
- Special situations that could not be tested
- Any testing performed in a consuming app -->

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->
- [x] Tested on Web

## PR Checklist
Code reviewer validation:
- General
	- [x] PR is linked to ticket(s)
	- [x] PR has `changelog` label applied if it's to be included in the changelog
	- [x] Acceptance criteria: 
		- All satisfied _or_
		- Documented reason for not being performed _or_
		- Split to separate ticket and ticket is linked by relevant AC(s)
	- [x] Above PR sections adequately filled out
	- [x] If any breaking changes, in accordance with the [pre-1.0.0 versioning guidelines](https://github.com/department-of-veterans-affairs/va-mobile-library#versioning-policy): a CU ticket has been created for the VA Mobile App detailing necessary adjustments with the package version that will be published by this ticket
- Code
	- [x] Tests are included if appropriate (or split to separate ticket)
	- [x] New functions have proper TSDoc annotations

## Publish
<!-- Most changes entail a version increment; section can be removed for PRs exclusively within non-ship-relevant files (e.g. unit tests, Storybook stories) -->
While changes warrant a new version [per the versioning guidelines](https://github.com/department-of-veterans-affairs/va-mobile-library#versioning-policy), will be handled by #216.
