### PR TITLE
[Feature] Link - Visual QA Updates/Fixes

### DIFF
--- a/packages/components/src/components/Link/Link.tsx
+++ b/packages/components/src/components/Link/Link.tsx
@@ -7,6 +7,7 @@ import {
   TextProps,
   TextStyle,
   View,
+  ViewStyle,
 } from 'react-native'
 import React, { FC } from 'react'
 
@@ -212,9 +213,18 @@ export const Link: FC<LinkProps> = ({
       linkColor = isDarkMode ? Colors.uswdsBlueVivid30 : Colors.primary
   }
 
+  const iconViewStyle: ViewStyle = {
+    marginRight: 5, // Spacer to text
+    // Below keeps icon aligned with first row of text, centered, and scalable
+    alignSelf: 'flex-start',
+    minHeight: 30,
+    alignItems: 'center',
+    justifyContent: 'center',
+  }
+
   const iconDisplay =
     icon === 'no icon' ? null : (
-      <View style={{ marginRight: 5 }}>
+      <View style={iconViewStyle}>
         <Icon fill={linkColor} {...icon} />
       </View>
     )

--- a/packages/components/src/components/Link/Link.tsx
+++ b/packages/components/src/components/Link/Link.tsx
@@ -239,6 +239,7 @@ export const Link: FC<LinkProps> = ({
 
   const pressableProps: PressableProps = {
     onPress: _onPress,
+    hitSlop: 7,
     ...a11yProps,
     style: {
       flexDirection: 'row',


### PR DESCRIPTION
<!-- PR title naming convention:
'[Issue type] Brief summary of issue suitable for changelog or copy/paste issue title',
where Issue type = bug, feature, spike, CU (code upkeep), etc.-->

<!-- Preferred branch naming convention:
'[Issue type]/[Issue #]-[Your name]-[Summary of issue]',
where Issue type = bug, feature, spike, CU (code upkeep), etc.-->

<!-- Update w/ ticket number to cross-repo link PR and ticket; ZenHub URL does not work
**[Ticket # ](https://github.com/department-of-veterans-affairs/va-mobile-app/issues/# )**  -->

## Description of Change
<!-- Describe the change and context with which it was made beyond ACs unless straightforward.
Consider:
 - What is relevant to code reviewer(s) and not in the ticket?
 - What context may be relevant to a future dev or you in 6 months about this PR?
 - Did the course of work lead to notable dead ends? If so, why didn't they pan out?
 - Did the change add new dependencies? Why?
 - Were there important sources to link? Examples: an open bug with a dependency project, an article of someone else solving the same problem that was partially or wholly copied, external documentation relevant to solution -->

- Added hitSlop of 7 to RN Pressable that expands the pressable area 7 in all directions to achieve the minimum 44px height press target (with the 30px line height of text)
  - React Native automatically handles if that touch target causes conflicts with other display elements
- Added style props to the View wrapping the Icon (if present) so that:
   - It has the same minimum height of the text (line height 30) so that the icon is centered vertically
   - Icon remains aligned with the first line if the text is long enough to wrap
   - Icon can still scale fine both from OS scaling and manually increasing size with height/width parameters

### Screenshots/Video
<!-- Add screenshots or video as needed; before/after recommended if appropriate. 
Convenience side-by-side formatting:
Before/after: <img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" />
Accordion before/after: <details><summary>Before/after</summary><img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" /></details>
-->

iOS (Android similar) screenshot showing touch target height 44 (30 + 7 top + 7 bottom):
<img src="https://github.com/department-of-veterans-affairs/va-mobile-library/assets/8690976/2ecf2f67-cf47-4398-8ff8-9587d28bb8ac" width="49%" />

Web showing alignment for long text + icon box keeping it aligned:

https://github.com/department-of-veterans-affairs/va-mobile-library/assets/8690976/21ab7936-f388-4709-a990-dba04873db54

## Testing
<!-- Describe testing conducted to validate changes.
Consider highlighting:
- What testing was not explicitly done and may be relevant for QA? 
- Edge cases validated
- Special situations that could not be tested
- Any testing performed in a consuming app -->

Notes: 
- Doing long text validation on iOS/Android was pushing the icon off the display to the side, but this was believed to be an issue with Storybook's viewport that would not manifest when embedded with a display within an app
   - Confirmed on main this is a preexisting weirdness
- Web does not seem to respect the RN Pressable's hitSlop property expanding touch target--as Web is just for demonstration purposes, this was deemed acceptable

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->
- [x] Tested on Web

## PR Checklist
Code reviewer validation:
- General
	- [x] PR is linked to ticket(s)
	- [x] PR has `changelog` label applied if it's to be included in the changelog
	- [x] Acceptance criteria: 
		- All satisfied _or_
		- Documented reason for not being performed _or_
		- Split to separate ticket and ticket is linked by relevant AC(s)
	- [x] Above PR sections adequately filled out
	- [x] If any breaking changes, in accordance with the [pre-1.0.0 versioning guidelines](https://github.com/department-of-veterans-affairs/va-mobile-library#versioning-policy): a CU ticket has been created for the VA Mobile App detailing necessary adjustments with the package version that will be published by this ticket
- Code
	- [x] Tests are included if appropriate (or split to separate ticket)
	- [x] New functions have proper TSDoc annotations

## Publish
<!-- Most changes entail a version increment; section can be removed for PRs exclusively within non-ship-relevant files (e.g. unit tests, Storybook stories) -->
While changes warrant a new version [per the versioning guidelines](https://github.com/department-of-veterans-affairs/va-mobile-library#versioning-policy), Link has not been officially published yet so it'll be deferred to #216 
