### PR TITLE
[Feature] Add tokens for Snackbar and Alert components

### DIFF
--- a/packages/tokens/figma/dark.json
+++ b/packages/tokens/figma/dark.json
@@ -527,6 +527,18 @@
     "$value": "{uswds-system-color-red-warm-10}",
     "$type": "color"
   },
+  "vads-color-feedback-border-error-on-dark": {
+    "$value": "{vads-color-secondary}",
+    "$type": "color"
+  },
+  "vads-color-feedback-border-info-on-dark": {
+    "$value": "{vads-color-primary-alt-light}",
+    "$type": "color"
+  },
+  "vads-color-feedback-border-success-on-dark": {
+    "$value": "{vads-color-green-light}",
+    "$type": "color"
+  },
   "vads-color-feedback-border-warning-on-dark": {
     "$value": "{uswds-system-color-yellow-vivid-20}",
     "$type": "color"
@@ -549,6 +561,10 @@
   },
   "vads-color-foreground-default-on-dark": {
     "$value": "{vads-color-base-lightest}",
+    "$type": "color"
+  },
+  "vads-color-foreground-inverse-on-dark": {
+    "$value": "{vads-color-base-darkest}",
     "$type": "color"
   },
   "vads-color-gibill-accent": {
@@ -753,6 +769,10 @@
   },
   "vads-color-success-lighter": {
     "$value": "{uswds-system-color-green-cool-5}",
+    "$type": "color"
+  },
+  "vads-color-surface-inverse-on-dark": {
+    "$value": "{vads-color-base-lightest}",
     "$type": "color"
   },
   "vads-color-surface-secondary-on-dark": {

--- a/packages/tokens/figma/light.json
+++ b/packages/tokens/figma/light.json
@@ -535,8 +535,44 @@
     "$value": "{uswds-system-color-red-warm-10}",
     "$type": "color"
   },
+  "vads-color-feedback-border-error-on-light": {
+    "$value": "{vads-color-error}",
+    "$type": "color"
+  },
+  "vads-color-feedback-border-info-on-light": {
+    "$value": "{vads-color-info}",
+    "$type": "color"
+  },
+  "vads-color-feedback-border-success-on-light": {
+    "$value": "{vads-color-success}",
+    "$type": "color"
+  },
+  "vads-color-feedback-border-warning-on-light": {
+    "$value": "{vads-color-warning}",
+    "$type": "color"
+  },
+  "vads-color-feedback-surface-error-on-light": {
+    "$value": "{vads-color-error-lighter}",
+    "$type": "color"
+  },
+  "vads-color-feedback-surface-info-on-light": {
+    "$value": "{vads-color-info-lighter}",
+    "$type": "color"
+  },
+  "vads-color-feedback-surface-success-on-light": {
+    "$value": "{vads-color-success-lighter}",
+    "$type": "color"
+  },
+  "vads-color-feedback-surface-warning-on-light": {
+    "$value": "{vads-color-warning-lighter}",
+    "$type": "color"
+  },
   "vads-color-foreground-default-on-light": {
     "$value": "{vads-color-base}",
+    "$type": "color"
+  },
+  "vads-color-foreground-inverse-on-light": {
+    "$value": "{vads-color-base-lightest}",
     "$type": "color"
   },
   "vads-color-gibill-accent": {
@@ -741,6 +777,10 @@
   },
   "vads-color-success-lighter": {
     "$value": "{uswds-system-color-green-cool-5}",
+    "$type": "color"
+  },
+  "vads-color-surface-inverse-on-light": {
+    "$value": "{vads-color-base-darkest}",
     "$type": "color"
   },
   "vads-color-surface-secondary-on-light": {

--- a/packages/tokens/src/tokens/color/semantic-dark.json
+++ b/packages/tokens/src/tokens/color/semantic-dark.json
@@ -6,6 +6,13 @@
       "category": "color"
     }
   },
+  "vads-color-foreground-inverse-on-dark": {
+    "name": "vads-color-foreground-inverse-on-dark",
+    "value": "{vads-color-base-darkest.*.value}",
+    "attributes": {
+      "category": "color"
+    }
+  },
   "vads-color-surface-secondary-on-dark": {
     "name": "vads-color-surface-secondary-on-dark",
     "value": "{vads-color-base-darker.*.value}",
@@ -13,9 +20,37 @@
       "category": "color"
     }
   },
+  "vads-color-surface-inverse-on-dark": {
+    "name": "vads-color-surface-inverse-on-dark",
+    "value": "{vads-color-base-lightest.*.value}",
+    "attributes": {
+      "category": "color"
+    }
+  },
   "vads-color-action-foreground-default-on-dark": {
     "name": "vads-color-action-foreground-default-on-dark",
     "value": "{uswds-system-color-blue-vivid-30}",
+    "attributes": {
+      "category": "color"
+    }
+  },
+  "vads-color-feedback-border-info-on-dark": {
+    "name": "vads-color-feedback-border-info-on-dark",
+    "value": "{vads-color-primary-alt-light.*.value}",
+    "attributes": {
+      "category": "color"
+    }
+  },
+  "vads-color-feedback-border-success-on-dark": {
+    "name": "vads-color-feedback-border-success-on-dark",
+    "value": "{vads-color-green-light.*.value}",
+    "attributes": {
+      "category": "color"
+    }
+  },
+  "vads-color-feedback-border-error-on-dark": {
+    "name": "vads-color-feedback-border-error-on-dark",
+    "value": "{vads-color-secondary.*.value}",
     "attributes": {
       "category": "color"
     }

--- a/packages/tokens/src/tokens/color/semantic-light.json
+++ b/packages/tokens/src/tokens/color/semantic-light.json
@@ -6,9 +6,23 @@
       "category": "color"
     }
   },
+  "vads-color-foreground-inverse-on-light": {
+    "name": "vads-color-foreground-inverse-on-light",
+    "value": "{vads-color-base-lightest.*.value}",
+    "attributes": {
+      "category": "color"
+    }
+  },
   "vads-color-surface-secondary-on-light": {
     "name": "vads-color-surface-secondary-on-light",
     "value": "{vads-color-base-lighter.*.value}",
+    "attributes": {
+      "category": "color"
+    }
+  },
+  "vads-color-surface-inverse-on-light": {
+    "name": "vads-color-surface-inverse-on-light",
+    "value": "{vads-color-base-darkest.*.value}",
     "attributes": {
       "category": "color"
     }
@@ -19,5 +33,61 @@
     "attributes": {
       "category": "color"
     }
-  }
+  },
+  "vads-color-feedback-border-info-on-light": {
+    "name": "vads-color-feedback-border-info-on-light",
+    "value": "{vads-color-info.*.value}",
+    "attributes": {
+      "category": "color"
+    }
+  },
+  "vads-color-feedback-border-success-on-light": {
+    "name": "vads-color-feedback-border-success-on-light",
+    "value": "{vads-color-success.*.value}",
+    "attributes": {
+      "category": "color"
+    }
+  },
+  "vads-color-feedback-border-warning-on-light": {
+    "name": "vads-color-feedback-border-warning-on-light",
+    "value": "{vads-color-warning.*.value}",
+    "attributes": {
+      "category": "color"
+    }
+  },  
+  "vads-color-feedback-border-error-on-light": {
+    "name": "vads-color-feedback-border-error-on-light",
+    "value": "{vads-color-error.*.value}",
+    "attributes": {
+      "category": "color"
+    }
+  },
+  "vads-color-feedback-surface-info-on-light": {
+    "name": "vads-color-feedback-surface-info-on-light",
+    "value": "{vads-color-info-lighter.*.value}",
+    "attributes": {
+      "category": "color"
+    }
+  },
+  "vads-color-feedback-surface-success-on-light": {
+    "name": "vads-color-feedback-surface-success-on-light",
+    "value": "{vads-color-success-lighter.*.value}",
+    "attributes": {
+      "category": "color"
+    }
+  },
+  "vads-color-feedback-surface-warning-on-light": {
+    "name": "vads-color-feedback-warning-success-on-light",
+    "value": "{vads-color-success-warning.*.value}",
+    "attributes": {
+      "category": "color"
+    }
+  },
+  "vads-color-feedback-surface-error-on-light": {
+    "name": "vads-color-feedback-surface-error-on-light",
+    "value": "{vads-color-error-lighter.*.value}",
+    "attributes": {
+      "category": "color"
+    }
+  },
 }

--- a/packages/tokens/src/tokens/color/semantic-light.json
+++ b/packages/tokens/src/tokens/color/semantic-light.json
@@ -78,7 +78,7 @@
   },
   "vads-color-feedback-surface-warning-on-light": {
     "name": "vads-color-feedback-warning-success-on-light",
-    "value": "{vads-color-success-warning.*.value}",
+    "value": "{vads-color-warning-lighter.*.value}",
     "attributes": {
       "category": "color"
     }

--- a/packages/tokens/src/tokens/color/semantic-light.json
+++ b/packages/tokens/src/tokens/color/semantic-light.json
@@ -89,5 +89,5 @@
     "attributes": {
       "category": "color"
     }
-  },
+  }
 }


### PR DESCRIPTION
<!-- PR title naming convention:
'[Issue type] Brief summary of issue suitable for changelog or copy/paste issue title',
where Issue type = bug, feature, spike, CU (code upkeep), etc.-->

<!-- Preferred branch naming convention:
'[Issue type]/[Issue #]-[Your name]-[Summary of issue]',
where Issue type = bug, feature, spike, CU (code upkeep), etc.-->

Closes #331 

## Description of Change
<!-- Describe the change and context with which it was made beyond ACs unless straightforward.
Consider:
 - What is relevant to code reviewer(s) and not in the ticket?
 - What context may be relevant to a future dev or you in 6 months about this PR?
 - Did the course of work lead to notable dead ends? If so, why didn't they pan out?
 - Did the change add new dependencies? Why?
 - Were there important sources to link? Examples: an open bug with a dependency project, an article of someone else solving the same problem that was partially or wholly copied, external documentation relevant to solution
 -->
**Added 10 tokens to semantic-light**
- vads-color-foreground-inverse-on-light
- vads-color-surface-inverse-on-light
- vads-color-feedback-border-info-on-light
- vads-color-feedback-border-success-on-light
- vads-color-feedback-border-warning-on-light
- vads-color-feedback-border-error-on-light
- vads-color-feedback-surface-info-on-light
- vads-color-feedback-surface-success-on-light
- vads-color-feedback-surface-warning-on-light
- vads-color-feedback-surface-error-on-light

**Added 5 tokens to semantic-dark**
- vads-color-foreground-inverse-on-dark
- vads-color-surface-inverse-on-dark
- vads-color-feedback-border-info-on-dark
- vads-color-feedback-border-success-on-dark
- vads-color-feedback-border-error-on-dark

#### Testing Packages
<!-- List or range of alpha/beta packages published in association with this PR, if any -->
N/A

### Screenshots/Video
<!-- Add screenshots or video as needed; before/after recommended if appropriate. 
Convenience side-by-side formatting:
Before/after: <img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" />
Accordion before/after: <details><summary>Before/after</summary><img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" /></details>
-->
N/A

## PR Checklist
Code reviewer validation:
- General
	- [x] PR is linked to ticket(s)
	- [x] PR has `changelog` label applied if it's to be included in the changelog
	- [x] Acceptance criteria: 
		- All satisfied _or_
		- Documented reason for not being performed _or_
		- Split to separate ticket and ticket is linked by relevant AC(s)
	- [x] Above PR sections adequately filled out
	- [x] If any breaking changes, in accordance with the [pre-1.0.0 versioning guidelines](https://github.com/department-of-veterans-affairs/va-mobile-library#versioning-policy): a CU ticket has been created for the VA Mobile App detailing necessary adjustments with the package version that will be published by this ticket
- Code
	- [x] Tests are included if appropriate (or split to separate ticket)
	- [x] New functions have proper TSDoc annotations

## Publish
<!-- Most changes entail a version increment; section can be removed for PRs exclusively within non-ship-relevant files (e.g. unit tests, Storybook stories) -->
If changes warrant a new version [per the versioning guidelines](https://github.com/department-of-veterans-affairs/va-mobile-library#versioning-policy) and the PR is approved and ready to merge:
- [x] Merge `main` into branch
- [x] Merge branch to `main`
- [x] Verify that [Check Component Integrations](https://github.com/department-of-veterans-affairs/va-mobile-library/actions/workflows/check-component-integrations.yml) workflow ran successfully
- [x] [Publish new version](https://github.com/department-of-veterans-affairs/va-mobile-library/actions/workflows/publish.yml) after merging
