### PR TITLE
[Feature] Prevent screen reader from focusing content behind Snackbar

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/mobile-component-library",
-  "version": "0.21.1-alpha.0",
+  "version": "0.21.1-alpha.5",
   "description": "VA Design System Mobile Component Library",
   "main": "src/index.tsx",
   "scripts": {

--- a/packages/components/src/components/Snackbar/Snackbar.stories.tsx
+++ b/packages/components/src/components/Snackbar/Snackbar.stories.tsx
@@ -34,6 +34,11 @@ export default meta
 
 type Story = StoryObj<SnackbarProps>
 
+/**
+ * Handles rendering the story in non-web platforms to have functional Snackbar
+ * @param props - Arguments from `args` list
+ * @returns Flat Button display with onPress logic to pull up the Snackbar
+ */
 const mobileComponentRenderer = (props: SnackbarProps) => {
   const { isError, messageA11y, onActionPressed } = props.data || {}
   const onPressSnackbar = () => {
@@ -53,7 +58,7 @@ export const _Snackbar: Story = {
     message: 'Message moved to Test Folder',
     data: {
       isError: false,
-      messageA11y: 'Message moved to Custom Folder with a11y',
+      messageA11y: 'Message moved to Test Folder with accessibility override',
       onActionPressed: () => console.log('Action pressed'),
     },
   },

--- a/packages/components/src/components/Snackbar/Snackbar.tsx
+++ b/packages/components/src/components/Snackbar/Snackbar.tsx
@@ -70,11 +70,18 @@ export const SnackbarProvider: React.FC = () => {
     <Toast
       animationDuration={100}
       duration={1000000000000} // Essentially indefinite until dismissed
-      offset={50}
+      offset={-20}
       placement="bottom"
       ref={(ref) => ((globalThis.snackbar as ToastContainer | null) = ref)}
       renderToast={(toast) => <Snackbar {...toast} />}
       swipeEnabled={false}
+      // style={{
+      //   accessible: true,
+      //   pointerEvents: 'auto',
+      //   importantForAccessibility: 'yes',
+      //   'aria-labelledby': 'gogo',
+      //   role: 'alert',
+      // }}
     />
   )
 }
@@ -167,6 +174,12 @@ export const Snackbar: FC<SnackbarProps> = (toast) => {
   // }
 
   const containerProps: ViewProps = {
+    // accessible: true,
+    // pointerEvents: 'auto',
+    // importantForAccessibility: 'yes',
+    // 'aria-labelledby': 'gogo',
+    // role: 'alert',
+    tabIndex: 0,
     style: {
       alignItems: 'center',
       backgroundColor: theme.vadsColorSurfaceInverse,
@@ -177,12 +190,14 @@ export const Snackbar: FC<SnackbarProps> = (toast) => {
       gap: 5,
       minHeight: 44,
       padding: sizing._12,
+      // pointerEvents: 'auto', // Override library so Snackbar is touchable
       marginHorizontal: sizing._20,
     },
   }
 
   const iconAndMessageContainer: ViewProps = {
     accessible: true,
+    // nativeID: 'gogo',
     role: 'alert',
     style: {
       flexDirection: 'row',

--- a/packages/components/src/components/Snackbar/Snackbar.tsx
+++ b/packages/components/src/components/Snackbar/Snackbar.tsx
@@ -70,18 +70,11 @@ export const SnackbarProvider: React.FC = () => {
     <Toast
       animationDuration={100}
       duration={1000000000000} // Essentially indefinite until dismissed
-      offset={-20}
+      offset={50}
       placement="bottom"
       ref={(ref) => ((globalThis.snackbar as ToastContainer | null) = ref)}
       renderToast={(toast) => <Snackbar {...toast} />}
       swipeEnabled={false}
-      // style={{
-      //   accessible: true,
-      //   pointerEvents: 'auto',
-      //   importantForAccessibility: 'yes',
-      //   'aria-labelledby': 'gogo',
-      //   role: 'alert',
-      // }}
     />
   )
 }
@@ -174,12 +167,9 @@ export const Snackbar: FC<SnackbarProps> = (toast) => {
   // }
 
   const containerProps: ViewProps = {
-    // accessible: true,
-    // pointerEvents: 'auto',
-    // importantForAccessibility: 'yes',
-    // 'aria-labelledby': 'gogo',
-    // role: 'alert',
-    tabIndex: 0,
+    accessibilityViewIsModal: true, // iOS only
+    tabIndex: 0, // Android only
+    // Above props prevent screen reader from tap focusing elements behind the Snackbar
     style: {
       alignItems: 'center',
       backgroundColor: theme.vadsColorSurfaceInverse,
@@ -190,14 +180,12 @@ export const Snackbar: FC<SnackbarProps> = (toast) => {
       gap: 5,
       minHeight: 44,
       padding: sizing._12,
-      // pointerEvents: 'auto', // Override library so Snackbar is touchable
       marginHorizontal: sizing._20,
     },
   }
 
   const iconAndMessageContainer: ViewProps = {
     accessible: true,
-    // nativeID: 'gogo',
     role: 'alert',
     style: {
       flexDirection: 'row',


### PR DESCRIPTION
<!-- PR title naming convention:
'[Issue type] Brief summary of issue suitable for changelog or copy/paste issue title',
where Issue type = bug, feature, spike, CU (code upkeep), etc.-->

<!-- Preferred branch naming convention:
'[Issue type]/[Issue #]-[Your name]-[Summary of issue]',
where Issue type = bug, feature, spike, CU (code upkeep), etc.-->

## Description of Change
<!-- Describe the change and context with which it was made beyond ACs unless straightforward.
Consider:
 - What is relevant to code reviewer(s) and not in the ticket?
 - What context may be relevant to a future dev or you in 6 months about this PR?
 - Did the course of work lead to notable dead ends? If so, why didn't they pan out?
 - Did the change add new dependencies? Why?
 - Were there important sources to link? Examples: an open bug with a dependency project, an article of someone else solving the same problem that was partially or wholly copied, external documentation relevant to solution
 -->
Added two props to the outermost container of the Snackbar display, one for each iOS and Android. Both effectively say the element should be focusable over other views (e.g. the ones below them).

Also added story documentation/a11y tweaks I'd made for a prior ticket but forgot to commit before merging.

#### Testing Packages
<!-- List or range of alpha/beta packages published in association with this PR, if any -->
- [0.21.1-alpha.5](https://www.npmjs.com/package/@department-of-veterans-affairs/mobile-component-library/v/0.21.1-alpha.5)

### Screenshots/Video
<!-- Add screenshots or video as needed; before/after recommended if appropriate. 
Convenience side-by-side formatting:
Before/after: <img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" />
Accordion before/after: <details><summary>Before/after</summary><img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" /></details>
-->

iOS (first with fix commented out demoing the tap through the Snackbar then "Refresh" around 16 seconds is with fix enabled):

https://github.com/user-attachments/assets/ae1f9ee9-8109-4b2c-b8ed-a45ee8b4c9c5

Android (first with fix commented out demoing the tap through the Snackbar then around 17 seconds is with fix enabled):

https://github.com/user-attachments/assets/4c5cfb5a-da6b-4e14-8f15-6ae0b23fe62d

## Testing
<!-- Describe testing conducted to validate changes.
Consider highlighting:
- What testing was not explicitly done and may be relevant for QA? 
- Edge cases validated
- Special situations that could not be tested
- Any testing performed in a consuming app -->

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->
- Not tested on Web
   - We don't test screen readers on web as an unsupported platform
   - The way the Snackbar story is configured for web wouldn't encounter the issue
   - The props used are iOS/Android specific and should not do anything on web

## PR Checklist
Code reviewer validation:
- General
	- [x] PR is linked to ticket(s)
	- [x] PR has `changelog` label applied if it's to be included in the changelog
	- [x] Acceptance criteria: 
		- All satisfied _or_
		- Documented reason for not being performed _or_
		- Split to separate ticket and ticket is linked by relevant AC(s)
	- [x] Above PR sections adequately filled out
	- [x] If any breaking changes, in accordance with the [pre-1.0.0 versioning guidelines](https://github.com/department-of-veterans-affairs/va-mobile-library#versioning-policy): a CU ticket has been created for the VA Mobile App detailing necessary adjustments with the package version that will be published by this ticket
- Code
	- [x] Tests are included if appropriate (or split to separate ticket)
	- [x] New functions have proper TSDoc annotations

## Publish
<!-- Most changes entail a version increment; section can be removed for PRs exclusively within non-ship-relevant files (e.g. unit tests, Storybook stories) -->
While changes warrant a new version [per the versioning guidelines](https://github.com/department-of-veterans-affairs/va-mobile-library#versioning-policy), we are postponing publishing Snackbar until complete.
