### PR TITLE
[Bug] Link - Flagship crash mitigation efforts

### DIFF
--- a/packages/components/src/components/Link/Link.stories.tsx
+++ b/packages/components/src/components/Link/Link.stories.tsx
@@ -124,6 +124,11 @@ export const _ExternalLink: Story = {
       onCancel: () => console.log('Analytics event: Canceled'),
       onPress: () => console.log('Analytics event: Pressed'),
       onConfirm: () => console.log('Analytics event: Confirmed'),
+      onOpenURLError: (e, url) => {
+        console.log(JSON.stringify(e))
+        console.log('Error: ' + e)
+        console.log('Error opening URL: ' + url)
+      },
     },
   },
 }

--- a/packages/components/src/components/Link/Link.test.tsx
+++ b/packages/components/src/components/Link/Link.test.tsx
@@ -81,7 +81,9 @@ describe('Link', () => {
       render(<Link {...commonProps} />)
       const icon = screen.UNSAFE_queryByType(Icon)
 
-      expect(icon).toBeNull()
+      expect(icon?.props.name).toBeUndefined()
+      expect(icon?.props.svg).toBeUndefined()
+      expect(icon?.props.noIcon).toBeDefined()
     })
   })
 
@@ -414,7 +416,9 @@ describe('Link', () => {
       render(<Link {...iconOverrideProps} icon={'no icon'} />)
       const icon = screen.UNSAFE_queryByType(Icon)
 
-      expect(icon).toBeFalsy()
+      expect(icon?.props.name).toBeUndefined()
+      expect(icon?.props.svg).toBeUndefined()
+      expect(icon?.props.noIcon).toBeDefined()
     })
   })
 

--- a/packages/components/src/components/Link/Link.tsx
+++ b/packages/components/src/components/Link/Link.tsx
@@ -149,7 +149,7 @@ export const Link: FC<LinkProps> = ({
     lineHeight: 30,
   }
 
-  let _icon: IconProps | 'no icon'
+  let _icon: IconProps
 
   /** Function to massage Partial<IconProps> data into IconProps based on variant icon defaults */
   const setIcon = (name?: IconProps['name']) => {
@@ -268,7 +268,7 @@ export const Link: FC<LinkProps> = ({
     <ComponentWrapper>
       <Pressable {...pressableProps} testID={testID}>
         <Icon fill={linkColor} {..._icon} />
-        {icon === 'no icon' ? null : <Spacer size="2xs" horizontal />}
+        {_icon.noIcon ? null : <Spacer size="2xs" horizontal />}
         <Text style={textStyle}>{text}</Text>
       </Pressable>
     </ComponentWrapper>

--- a/packages/components/src/components/Link/Link.tsx
+++ b/packages/components/src/components/Link/Link.tsx
@@ -4,11 +4,8 @@ import {
   Text,
   TextProps,
   TextStyle,
-  View,
-  ViewStyle,
-  useWindowDimensions,
 } from 'react-native'
-import { spacing } from '@department-of-veterans-affairs/mobile-tokens'
+import { t } from 'i18next'
 import React, { FC } from 'react'
 
 import { ComponentWrapper } from '../../wrapper'
@@ -19,7 +16,7 @@ import {
   useExternalLink,
 } from '../../utils/OSfunctions'
 import { Icon, IconProps } from '../Icon/Icon'
-import { t } from 'i18next'
+import { Spacer } from '../Spacer/Spacer'
 import { useTheme } from '../../utils'
 
 // Convenience type to default type-specific props to not existing/being optional
@@ -96,6 +93,7 @@ export type LinkAnalytics = {
   onPress?: () => void
   onConfirm?: () => void
   onCancel?: () => void
+  onOpenURLError?: (e?: unknown, url?: LinkProps['url']) => void
 }
 
 export type LinkProps = linkTypes & {
@@ -142,7 +140,6 @@ export const Link: FC<LinkProps> = ({
   url,
 }) => {
   const theme = useTheme()
-  const fontScale = useWindowDimensions().fontScale
   const launchExternalLink = useExternalLink()
 
   // TODO: Replace with typography tokens
@@ -158,22 +155,20 @@ export const Link: FC<LinkProps> = ({
   const setIcon = (name?: IconProps['name']) => {
     switch (icon) {
       case 'no icon':
-        return 'no icon'
+        return { noIcon: true }
       case undefined:
         if (name) return { name }
-        return 'no icon'
+        return { noIcon: true }
       default:
         if (icon.svg) return icon as IconProps
-        if (!name && !icon.name) return 'no icon'
+        if (!name && !icon.name) return { noIcon: true }
 
         if (!icon.name) icon.name = name
         return icon as IconProps
     }
   }
 
-  let _onPress: () => void = async () => {
-    null // Empty function to keep TS happy a function exists
-  }
+  let _onPress: () => void
 
   /** Handler for links not using launchExternalLink prompt */
   const customOnPress: () => void = () => {
@@ -192,15 +187,11 @@ export const Link: FC<LinkProps> = ({
       break
     case 'call':
       _icon = setIcon('Phone')
-      _onPress = async (): Promise<void> => {
-        launchExternalLink(`tel:${phoneNumber}`, analytics)
-      }
+      _onPress = () => launchExternalLink(`tel:${phoneNumber}`, analytics)
       break
     case 'call TTY':
       _icon = setIcon('TTY')
-      _onPress = async (): Promise<void> => {
-        launchExternalLink(`tel:${TTYnumber}`, analytics)
-      }
+      _onPress = () => launchExternalLink(`tel:${TTYnumber}`, analytics)
       break
     case 'custom':
       _icon = setIcon()
@@ -209,23 +200,19 @@ export const Link: FC<LinkProps> = ({
     case 'directions':
       _icon = setIcon('Directions')
       const directions = FormDirectionsUrl(locationData)
-      _onPress = async (): Promise<void> => {
-        launchExternalLink(directions, analytics, promptText)
-      }
+      _onPress = () => launchExternalLink(directions, analytics, promptText)
       break
     case 'text':
       _icon = setIcon('PhoneIphone')
-      _onPress = async (): Promise<void> => {
-        launchExternalLink(`sms:${textNumber}`, analytics)
-      }
+      _onPress = () => launchExternalLink(`sms:${textNumber}`, analytics)
       break
     case 'url':
       _icon = setIcon('Launch')
-      _onPress = async (): Promise<void> => {
-        launchExternalLink(url, analytics, promptText)
-      }
+      _onPress = () => launchExternalLink(url, analytics, promptText)
       break
   }
+
+  _icon.alignWithTextLineHeight = font.lineHeight
 
   let linkColor: string
 
@@ -236,22 +223,6 @@ export const Link: FC<LinkProps> = ({
     default:
       linkColor = theme.vadsColorActionForegroundDefault
   }
-
-  const iconViewStyle: ViewStyle = {
-    marginRight: spacing.vadsSpace2xs, // Spacer to text
-    // Below keeps icon aligned with first row of text, centered, and scalable
-    alignSelf: 'flex-start',
-    minHeight: font.lineHeight * fontScale,
-    alignItems: 'center',
-    justifyContent: 'center',
-  }
-
-  const iconDisplay =
-    _icon === 'no icon' ? null : (
-      <View style={iconViewStyle}>
-        <Icon fill={linkColor} {..._icon} />
-      </View>
-    )
 
   let ariaValue
   if (typeof a11yValue === 'string') {
@@ -296,7 +267,8 @@ export const Link: FC<LinkProps> = ({
   return (
     <ComponentWrapper>
       <Pressable {...pressableProps} testID={testID}>
-        {iconDisplay}
+        <Icon fill={linkColor} {..._icon} />
+        {icon === 'no icon' ? null : <Spacer size="2xs" horizontal />}
         <Text style={textStyle}>{text}</Text>
       </Pressable>
     </ComponentWrapper>


### PR DESCRIPTION
<!-- PR title naming convention:
'[Issue type] Brief summary of issue suitable for changelog or copy/paste issue title',
where Issue type = bug, feature, spike, CU (code upkeep), etc.-->

<!-- Preferred branch naming convention:
'[Issue type]/[Issue #]-[Your name]-[Summary of issue]',
where Issue type = bug, feature, spike, CU (code upkeep), etc.-->

## Description of Change
<!-- Describe the change and context with which it was made beyond ACs unless straightforward.
Consider:
 - What is relevant to code reviewer(s) and not in the ticket?
 - What context may be relevant to a future dev or you in 6 months about this PR?
 - Did the course of work lead to notable dead ends? If so, why didn't they pan out?
 - Did the change add new dependencies? Why?
 - Were there important sources to link? Examples: an open bug with a dependency project, an article of someone else solving the same problem that was partially or wholly copied, external documentation relevant to solution
 -->
Efforts to make code more defensive against crashes:
1. Updated Link _onPress logic to no longer be async
   - Likely legacy carryover from flagship component that uses async for adding to calendar (as it needs to query device calendar permissions), design system Link omitted calendar as it necessitates native code so should not be relevant
2. Updated Icon component to allow a null passthrough and made the Link use it
   - Was noted as a potential error spot for the more/fewer hooks between renders as the no icon Link would return null while an icon-having Link would return the Icon component which contains hooks
   - With the null passthrough, it will always be "rendered" so the hooks should remain consistent
   - This adjustment also necessitated pulling the aligning the icon with the first row of text logic into the Icon component--I believe there's already a ticket outstanding to centralize that logic anyway and now it is so Alert/Snackbar/Checkbox can be updated accordingly if no issues are noted
3. The useExternalLink hook was updated to handle the unhandled promise errors from RN's Linking.openURL function when the URL is faulty
   - Entailed making the innards use async/await and try/catches
   - Should technically be impossible to fail for all Link types except `url`, but validated no longer getting unhandled promise warnings for various edge cases (see testing section below)
      - Other Link types apply a prefix (e.g. `tel:`) such that the `url` is not an empty string even if the consumer passed an empty string which results in weird behavior, but no warning of a failure

Updated 2 unit tests that broke from the changes in a manner expected based on the changes. Ticket #574 was created to more fully update unit tests separately due to time sensitivity of the changes.

## Testing
<!-- Describe testing conducted to validate changes.
Consider highlighting:
- What testing was not explicitly done and may be relevant for QA? 
- Edge cases validated
- Special situations that could not be tested
- Any testing performed in a consuming app -->
Defensive code 1 above:
- Validated the various link types in storybook still work as expected

Defensive code 2 above:
- Validated at differing font scaling that the icon remains aligned with the first row of text
- Validated with no icon that both icon was not present nor was the spacing to the link text
- Spot checked Alert component icon alignment still appeared as expected with different font scaling to verify the normal flow is still working as before

Defensive code 3 above:
- Validated new analytics working as expected
- Validated the various link types in storybook still work as expected
- Validated erroneous input:
   - Directions type:
      - "" opens maps app with no destination as expected
         - iOS points to some place in Ontario
         - Android points to a not far away business with "undefined" in the name
      - Did not explore manual overrides in code as it should behave the same as URL type below as a URL
   - Phone/TTY type:
      - "" phone/TTY still opens call logic with no number as before
      - Manually overriding removal of the `tel:` prefix yields expected hit of new analytic event
   - Text type:
      - "" text number opens messages logic with no number as expected
      - Manually overriding removal of the `sms:` prefix yields expected hit of new analytic event
   - URL type:
      - iOS:
         - `https://www.` yielded a server cannot be found error
         - `https://www` yielded the same
         - `https://` yielded a cannot open page error
         - `https:` yielded the same
         - `https` yielded a "dead" click but hit new analytic event w/ error object and error message: `Error: Unable to open URL: file:///private/var/containers/Bundle/Application/0CAB9745-B322-4A0B-90C7-63F66F13ACA9/Expo%20Go.app/https`
         - `http` yielded the same
         - `htt` yielded the same (no confirm dialog anymore, conditional on `http` start)
         - "" yielded the same "dead" click, but different error: `Invariant Violation: Invalid URL: cannot be empty`
      - Android:
         - `https://www.` yielded a can't find site error
         - `https://www` yielded the same
         - `https://` yielded the browser opening with URL `about:blank`
         - `https:` yielded the same
         - `https` yielded a "dead" click but hit new analytic event w/ robust error object and error message: `Error: Could not open URL 'https': No Activity found to handle Intent { act=android.intent.action.VIEW dat=https flg=0x10000000 }`
         - `http` yielded the same
         - `htt` yielded the same (no confirm dialog anymore, conditional on `http` start)
         - "" yielded the same "dead" click, but different error: `Invariant Violation: Invalid URL: cannot be empty`

An alpha build was considered for testing, but ultimately deemed not needed as these changes are ultimately self-contained to logic that is capable of being hit within Storybook. Additionally, it is aiming for quick turn-around with the app and app-level QA should cover any testing that would've been performed with an alpha build.

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->
- [x] Tested on Web

## PR Checklist
Code reviewer validation:
- General
	- [x] PR is linked to ticket(s)
	- [x] PR has `changelog` label applied if it's to be included in the changelog
	- [ ] Acceptance criteria: 
		- All satisfied _or_
		- Documented reason for not being performed _or_
		- Split to separate ticket and ticket is linked by relevant AC(s)
	- [ ] Above PR sections adequately filled out
	- [ ] If any breaking changes, in accordance with the [pre-1.0.0 versioning guidelines](https://github.com/department-of-veterans-affairs/va-mobile-library#versioning-policy): a CU ticket has been created for the VA Mobile App detailing necessary adjustments with the package version that will be published by this ticket
- Code
	- [ ] Tests are included if appropriate (or split to separate ticket)
	- [ ] New functions have proper TSDoc annotations

## Publish
<!-- Most changes entail a version increment; section can be removed for PRs exclusively within non-ship-relevant files (e.g. unit tests, Storybook stories) -->
If changes warrant a new version [per the versioning guidelines](https://github.com/department-of-veterans-affairs/va-mobile-library/blob/main/documentation/versioning.md) and the PR is approved and ready to merge:
- [ ] Merge `main` into branch
- [ ] Merge branch to `main`
- [ ] Verify that [Check Component Integrations](https://github.com/department-of-veterans-affairs/va-mobile-library/actions/workflows/check-component-integrations.yml) workflow ran successfully
- [ ] [Publish new version](https://github.com/department-of-veterans-affairs/va-mobile-library/actions/workflows/publish.yml) after merging
