### PR TITLE
[Feature] Revamp Segmented control internals to native

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/mobile-component-library",
-  "version": "0.34.0",
+  "version": "0.34.1-alpha.0",
   "description": "VA Design System Mobile Component Library",
   "main": "src/index.tsx",
   "scripts": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -42,8 +42,7 @@
     "i18next": "^23.12.2",
     "react-i18next": "^15.0.0",
     "react-native-svg": "15.11.2",
-    "react-native-toast-notifications": "^3.4.0",
-    "styled-components": "^6.1.12"
+    "react-native-toast-notifications": "^3.4.0"
   },
   "peerDependencies": {
     "@department-of-veterans-affairs/mobile-assets": "^0.15.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -86,7 +86,6 @@
     "gh-pages": "^6.1.1",
     "jest": "^29.7.0",
     "jest-expo": "~53.0.9",
-    "jest-styled-components": "^7.2.0",
     "metro-react-native-babel-preset": "^0.77.0",
     "react": "19.0.0",
     "react-docgen-typescript": "^2.4.0",

--- a/packages/components/src/components/Alert/Alert.test.tsx
+++ b/packages/components/src/components/Alert/Alert.test.tsx
@@ -1,7 +1,6 @@
 import 'react-native'
 import { fireEvent, render, screen } from '@testing-library/react-native'
 // Note: test renderer must be required after react-native.
-import 'jest-styled-components'
 
 import { Alert } from './Alert'
 import { Icon } from '../Icon/Icon'

--- a/packages/components/src/components/Button/Button.test.tsx
+++ b/packages/components/src/components/Button/Button.test.tsx
@@ -1,7 +1,6 @@
 import 'react-native'
 import { fireEvent, render, screen } from '@testing-library/react-native'
 // Note: test renderer must be required after react-native.
-import 'jest-styled-components'
 
 import { Button, ButtonVariants } from './Button'
 

--- a/packages/components/src/components/LoadingIndicator/LoadingIndicator.test.tsx
+++ b/packages/components/src/components/LoadingIndicator/LoadingIndicator.test.tsx
@@ -1,7 +1,6 @@
 import 'react-native'
 import { render, screen } from '@testing-library/react-native'
 // Note: test renderer must be required after react-native.
-import 'jest-styled-components'
 
 import { Icon } from '../Icon/Icon'
 import { LoadingIndicator, LoadingIndicatorProps } from './LoadingIndicator'

--- a/packages/components/src/components/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/components/src/components/SegmentedControl/SegmentedControl.test.tsx
@@ -84,7 +84,6 @@ describe('SegmentedControl', () => {
     const inactiveSegmentText = screen.getByText(labels[1])
 
     expect(activeSegment).toHaveStyle({
-      elevation: 4,
       backgroundColor: '#ffffff',
     })
 
@@ -93,7 +92,6 @@ describe('SegmentedControl', () => {
     })
 
     expect(inactiveSegment).toHaveStyle({
-      elevation: 0,
       backgroundColor: '#dfe1e2',
     })
 
@@ -111,7 +109,6 @@ describe('SegmentedControl', () => {
     const inactiveSegmentText = screen.getByText(labels[1])
 
     expect(activeSegment).toHaveStyle({
-      elevation: 4,
       backgroundColor: '#565c65',
     })
 
@@ -120,7 +117,6 @@ describe('SegmentedControl', () => {
     })
 
     expect(inactiveSegment).toHaveStyle({
-      elevation: 0,
       backgroundColor: '#3d4551',
     })
 

--- a/packages/components/src/components/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/components/src/components/SegmentedControl/SegmentedControl.test.tsx
@@ -1,7 +1,6 @@
 import 'react-native'
 import { fireEvent, render, screen } from '@testing-library/react-native'
 // Note: test renderer must be required after react-native.
-import 'jest-styled-components'
 import { ReactTestInstance } from 'react-test-renderer'
 
 import { SegmentedControl } from './SegmentedControl'

--- a/packages/components/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/components/src/components/SegmentedControl/SegmentedControl.tsx
@@ -1,36 +1,60 @@
 import { FC, useEffect } from 'react'
 import {
   Pressable,
-  Text as RNText,
+  PressableProps,
+  StyleSheet,
+  Text,
   TextStyle,
   View,
   ViewStyle,
 } from 'react-native'
 import { font, spacing } from '@department-of-veterans-affairs/mobile-tokens'
 import { useTranslation } from 'react-i18next'
-import styled from 'styled-components/native'
 
 import { ComponentWrapper } from '../../wrapper'
 import { PressableOpacityStyle, isIOS, useTheme } from '../../utils'
 
-type SegmentProps = {
-  /** Sets the background color */
-  backgroundColor: string
-  /** True if segment is selected, else false */
-  isSelected: boolean
-  /** Percent of width the segment is allocated */
-  widthPct: string
-}
+// Regular Pressable component instead of styled-component to avoid web compatibility issues
+const Segment: FC<
+  {
+    backgroundColor: string
+    isSelected: boolean
+    widthPct: string
+    children: React.ReactNode
+    onPress: () => void
+  } & Omit<PressableProps, 'onPress' | 'children'>
+> = ({
+  backgroundColor,
+  isSelected,
+  widthPct,
+  children,
+  onPress,
+  style,
+  ...props
+}) => {
+  const segmentStyle = StyleSheet.create({
+    segment: {
+      borderRadius: 8,
+      paddingHorizontal: spacing.vadsSpace2xs,
+      paddingVertical: spacing.vadsSpaceXs,
+      width: widthPct as '100%', // Type assertion for percentage strings
+      elevation: isSelected ? spacing.vadsSpace2xs : spacing.vadsSpaceNone,
+      backgroundColor: backgroundColor,
+    },
+  })
 
-const Segment = styled(Pressable)<SegmentProps>`
-  border-radius: 8px;
-  padding-horizontal: ${spacing.vadsSpace2xs}px;
-  padding-vertical: ${spacing.vadsSpaceXs}px;
-  width: ${(props) => props.widthPct};
-  elevation: ${(props) =>
-    props.isSelected ? spacing.vadsSpace2xs : spacing.vadsSpaceNone};
-  background-color: ${(props) => props.backgroundColor};
-`
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [
+        segmentStyle.segment,
+        typeof style === 'function' ? style({ pressed }) : style,
+      ]}
+      {...props}>
+      {children}
+    </Pressable>
+  )
+}
 
 /**
  * Props for {@link SegmentedControl}
@@ -128,9 +152,9 @@ export const SegmentedControl: FC<SegmentedControlProps> = ({
         accessibilityState={{ selected: isSelected }}
         style={PressableOpacityStyle()}
         testID={testIDs?.[index]}>
-        <RNText allowFontScaling={false} style={textStyle}>
+        <Text allowFontScaling={false} style={textStyle}>
           {label}
-        </RNText>
+        </Text>
       </Segment>
     )
   }

--- a/packages/components/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/components/src/components/SegmentedControl/SegmentedControl.tsx
@@ -2,8 +2,8 @@ import { FC, useEffect } from 'react'
 import {
   Pressable,
   PressableProps,
+  Text as RNText,
   StyleSheet,
-  Text,
   TextStyle,
   View,
   ViewStyle,
@@ -12,7 +12,7 @@ import { font, spacing } from '@department-of-veterans-affairs/mobile-tokens'
 import { useTranslation } from 'react-i18next'
 
 import { ComponentWrapper } from '../../wrapper'
-import { PressableOpacityStyle, isIOS, useTheme } from '../../utils'
+import { PressableOpacityStyle, useTheme } from '../../utils'
 
 // Regular Pressable component instead of styled-component to avoid web compatibility issues
 const Segment: FC<
@@ -123,13 +123,6 @@ export const SegmentedControl: FC<SegmentedControlProps> = ({
       total: labels.length,
     })
 
-    const accessibilityValueText = isIOS()
-      ? t('tab') +
-        ', ' +
-        (isSelected ? t('selected') + ', ' : '') +
-        a11yListPosition
-      : a11yListPosition
-
     const textStyle: TextStyle = {
       ...typography.vadsFontBodyLarge,
       fontFamily: isSelected ? 'SourceSansPro-Bold' : 'SourceSansPro-Regular',
@@ -146,15 +139,15 @@ export const SegmentedControl: FC<SegmentedControlProps> = ({
         key={index}
         widthPct={`${100 / labels.length}%`}
         aria-label={accessibilityLabel}
-        aria-valuetext={accessibilityValueText}
+        aria-valuetext={a11yListPosition}
         accessibilityHint={a11yHints ? a11yHints[index] : ''}
         role={'tab'}
         accessibilityState={{ selected: isSelected }}
         style={PressableOpacityStyle()}
         testID={testIDs?.[index]}>
-        <Text allowFontScaling={false} style={textStyle}>
+        <RNText allowFontScaling={false} style={textStyle}>
           {label}
-        </Text>
+        </RNText>
       </Segment>
     )
   }

--- a/packages/components/src/utils/translation/en.json
+++ b/packages/components/src/utils/translation/en.json
@@ -7,8 +7,6 @@
   "leaveAppAlert.title": "Leave the mobile app?",
   "listPosition": "{{position}} of {{total}}",
   "required": "Required",
-  "selected": "Selected",
-  "tab": "Tab",
   "tryAgain": "Try again",
   "undo": "Undo"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1793,7 +1793,6 @@ __metadata:
     react-native-web: "npm:^0.20.0"
     react-test-renderer: "npm:19.0.0"
     storybook: "npm:^9.0.15"
-    styled-components: "npm:^6.1.12"
     ts-jest: "npm:^29.2.3"
     typescript: "npm:^5.8.3"
     vite: "npm:^6.3.5"
@@ -1877,29 +1876,6 @@ __metadata:
   dependencies:
     "@types/hammerjs": "npm:^2.0.36"
   checksum: dbedc15a0e633f887c08394bd636faf6a3abd05726dc0909a0e01209d5860a752d9eca5e512da623aecfabe665f49f1d035de3103eb2f9022c5cea692f9cc9be
-  languageName: node
-  linkType: hard
-
-"@emotion/is-prop-valid@npm:1.2.2":
-  version: 1.2.2
-  resolution: "@emotion/is-prop-valid@npm:1.2.2"
-  dependencies:
-    "@emotion/memoize": "npm:^0.8.1"
-  checksum: bb1530dcb4e0e5a4fabb219279f2d0bc35796baf66f6241f98b0d03db1985c890a8cafbea268e0edefd5eeda143dbd5c09a54b5fba74cee8c69b98b13194af50
-  languageName: node
-  linkType: hard
-
-"@emotion/memoize@npm:^0.8.1":
-  version: 0.8.1
-  resolution: "@emotion/memoize@npm:0.8.1"
-  checksum: dffed372fc3b9fa2ba411e76af22b6bb686fb0cb07694fdfaa6dd2baeb0d5e4968c1a7caa472bfcf06a5997d5e7c7d16b90e993f9a6ffae79a2c3dbdc76dfe78
-  languageName: node
-  linkType: hard
-
-"@emotion/unitless@npm:0.8.1":
-  version: 0.8.1
-  resolution: "@emotion/unitless@npm:0.8.1"
-  checksum: a1ed508628288f40bfe6dd17d431ed899c067a899fa293a13afe3aed1d70fac0412b8a215fafab0b42829360db687fecd763e5f01a64ddc4a4b58ec3112ff548
   languageName: node
   linkType: hard
 
@@ -4177,13 +4153,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/stylis@npm:4.2.5":
-  version: 4.2.5
-  resolution: "@types/stylis@npm:4.2.5"
-  checksum: 23f5b35a3a04f6bb31a29d404fa1bc8e0035fcaff2356b4047743a057e0c37b2eba7efe14d57dd2b95b398cea3bac294d9c6cd93ed307d8c0b7f5d282224b469
-  languageName: node
-  linkType: hard
-
 "@types/tough-cookie@npm:*":
   version: 4.0.5
   resolution: "@types/tough-cookie@npm:4.0.5"
@@ -5641,13 +5610,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"camelize@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "camelize@npm:1.0.1"
-  checksum: 4c9ac55efd356d37ac483bad3093758236ab686192751d1c9daa43188cc5a07b09bd431eb7458a4efd9ca22424bba23253e7b353feb35d7c749ba040de2385fb
-  languageName: node
-  linkType: hard
-
 "caniuse-lite@npm:^1.0.30001726":
   version: 1.0.30001727
   resolution: "caniuse-lite@npm:1.0.30001727"
@@ -6176,13 +6138,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-color-keywords@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "css-color-keywords@npm:1.0.0"
-  checksum: af205a86c68e0051846ed91eb3e30b4517e1904aac040013ff1d742019b3f9369ba5658ba40901dbbc121186fc4bf0e75a814321cc3e3182fbb2feb81c6d9cb7
-  languageName: node
-  linkType: hard
-
 "css-in-js-utils@npm:^3.1.0":
   version: 3.1.0
   resolution: "css-in-js-utils@npm:3.1.0"
@@ -6202,17 +6157,6 @@ __metadata:
     domutils: "npm:^3.0.1"
     nth-check: "npm:^2.0.1"
   checksum: d79fffa97106007f2802589f3ed17b8c903f1c961c0fc28aa8a051eee0cbad394d8446223862efd4c1b40445a6034f626bb639cf2035b0bfc468544177593c99
-  languageName: node
-  linkType: hard
-
-"css-to-react-native@npm:3.2.0":
-  version: 3.2.0
-  resolution: "css-to-react-native@npm:3.2.0"
-  dependencies:
-    camelize: "npm:^1.0.0"
-    css-color-keywords: "npm:^1.0.0"
-    postcss-value-parser: "npm:^4.0.2"
-  checksum: fde850a511d5d3d7c55a1e9b8ed26b69a8ad4868b3487e36ebfbfc0b96fc34bc977d9cd1d61a289d0c74d3f9a662d8cee297da53d4433bf2e27d6acdff8e1003
   languageName: node
   linkType: hard
 
@@ -6292,7 +6236,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"csstype@npm:3.1.3, csstype@npm:^3.0.2":
+"csstype@npm:^3.0.2":
   version: 3.1.3
   resolution: "csstype@npm:3.1.3"
   checksum: 80c089d6f7e0c5b2bd83cf0539ab41474198579584fa10d86d0cafe0642202343cbc119e076a0b1aece191989477081415d66c9fefbf3c957fc2fc4b7009f248
@@ -11156,21 +11100,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-value-parser@npm:^4.0.2, postcss-value-parser@npm:^4.2.0":
+"postcss-value-parser@npm:^4.2.0":
   version: 4.2.0
   resolution: "postcss-value-parser@npm:4.2.0"
   checksum: f4142a4f56565f77c1831168e04e3effd9ffcc5aebaf0f538eee4b2d465adfd4b85a44257bb48418202a63806a7da7fe9f56c330aebb3cac898e46b4cbf49161
-  languageName: node
-  linkType: hard
-
-"postcss@npm:8.4.49, postcss@npm:~8.4.32":
-  version: 8.4.49
-  resolution: "postcss@npm:8.4.49"
-  dependencies:
-    nanoid: "npm:^3.3.7"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: f1b3f17aaf36d136f59ec373459f18129908235e65dbdc3aee5eef8eba0756106f52de5ec4682e29a2eab53eb25170e7e871b3e4b52a8f1de3d344a514306be3
   languageName: node
   linkType: hard
 
@@ -11182,6 +11115,17 @@ __metadata:
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
   checksum: 5127cc7c91ed7a133a1b7318012d8bfa112da9ef092dddf369ae699a1f10ebbd89b1b9f25f3228795b84585c72aabd5ced5fc11f2ba467eedf7b081a66fad024
+  languageName: node
+  linkType: hard
+
+"postcss@npm:~8.4.32":
+  version: 8.4.49
+  resolution: "postcss@npm:8.4.49"
+  dependencies:
+    nanoid: "npm:^3.3.7"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: f1b3f17aaf36d136f59ec373459f18129908235e65dbdc3aee5eef8eba0756106f52de5ec4682e29a2eab53eb25170e7e871b3e4b52a8f1de3d344a514306be3
   languageName: node
   linkType: hard
 
@@ -12533,13 +12477,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shallowequal@npm:1.1.0":
-  version: 1.1.0
-  resolution: "shallowequal@npm:1.1.0"
-  checksum: b926efb51cd0f47aa9bc061add788a4a650550bbe50647962113a4579b60af2abe7b62f9b02314acc6f97151d4cf87033a2b15fc20852fae306d1a095215396c
-  languageName: node
-  linkType: hard
-
 "shebang-command@npm:^2.0.0":
   version: 2.0.0
   resolution: "shebang-command@npm:2.0.0"
@@ -13017,37 +12954,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"styled-components@npm:^6.1.12":
-  version: 6.1.19
-  resolution: "styled-components@npm:6.1.19"
-  dependencies:
-    "@emotion/is-prop-valid": "npm:1.2.2"
-    "@emotion/unitless": "npm:0.8.1"
-    "@types/stylis": "npm:4.2.5"
-    css-to-react-native: "npm:3.2.0"
-    csstype: "npm:3.1.3"
-    postcss: "npm:8.4.49"
-    shallowequal: "npm:1.1.0"
-    stylis: "npm:4.3.2"
-    tslib: "npm:2.6.2"
-  peerDependencies:
-    react: ">= 16.8.0"
-    react-dom: ">= 16.8.0"
-  checksum: 8d20427a5debe54bfa3b55f79af2a3577551ed7f1d1cd34df986b73fd01ac519f9081b7737cc1f76e12fbc483fa50551e55be0bc984296e623cc6a2364697cd8
-  languageName: node
-  linkType: hard
-
 "styleq@npm:^0.1.3":
   version: 0.1.3
   resolution: "styleq@npm:0.1.3"
   checksum: 975d951792e65052f1f6e41aaad46492642ce4922b3dc36d4b49b37c8509f9a776794d8f275360f00116a5e6ab1e31514bdcd5840656c4e3213da6803fa12941
-  languageName: node
-  linkType: hard
-
-"stylis@npm:4.3.2":
-  version: 4.3.2
-  resolution: "stylis@npm:4.3.2"
-  checksum: 0410e1404cbeee3388a9e17587875211ce2f014c8379af0d1e24ca55878867c9f1ccc7b0ce9a156ca53f5d6e301391a82b0645522a604674a378b3189a4a1994
   languageName: node
   linkType: hard
 
@@ -13467,13 +13377,6 @@ __metadata:
     minimist: "npm:^1.2.6"
     strip-bom: "npm:^3.0.0"
   checksum: 09a5877402d082bb1134930c10249edeebc0211f36150c35e1c542e5b91f1047b1ccf7da1e59babca1ef1f014c525510f4f870de7c9bda470c73bb4e2721b3ea
-  languageName: node
-  linkType: hard
-
-"tslib@npm:2.6.2":
-  version: 2.6.2
-  resolution: "tslib@npm:2.6.2"
-  checksum: e03a8a4271152c8b26604ed45535954c0a45296e32445b4b87f8a5abdb2421f40b59b4ca437c4346af0f28179780d604094eb64546bee2019d903d01c6c19bdb
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,7 +17,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@adobe/css-tools@npm:^4.0.1, @adobe/css-tools@npm:^4.4.0":
+"@adobe/css-tools@npm:^4.4.0":
   version: 4.4.3
   resolution: "@adobe/css-tools@npm:4.4.3"
   checksum: 6d16c4d4b6752d73becf6e58611f893c7ed96e04017ff7084310901ccdbe0295171b722b158f6a2b0aa77182ef3446ffd62b39488fa5a7adab1f0dfe5ffafbae
@@ -1776,7 +1776,6 @@ __metadata:
     i18next: "npm:^23.12.2"
     jest: "npm:^29.7.0"
     jest-expo: "npm:~53.0.9"
-    jest-styled-components: "npm:^7.2.0"
     metro-react-native-babel-preset: "npm:^0.77.0"
     react: "npm:19.0.0"
     react-docgen-typescript: "npm:^2.4.0"
@@ -9086,17 +9085,6 @@ __metadata:
     pretty-format: "npm:^29.7.0"
     semver: "npm:^7.5.3"
   checksum: 6e9003c94ec58172b4a62864a91c0146513207bedf4e0a06e1e2ac70a4484088a2683e3a0538d8ea913bcfd53dc54a9b98a98cdfa562e7fe1d1339aeae1da570
-  languageName: node
-  linkType: hard
-
-"jest-styled-components@npm:^7.2.0":
-  version: 7.2.0
-  resolution: "jest-styled-components@npm:7.2.0"
-  dependencies:
-    "@adobe/css-tools": "npm:^4.0.1"
-  peerDependencies:
-    styled-components: ">= 5"
-  checksum: 44eecf73cd1ee50686c9c16517222e2c012422dd7d90a07813f82f3ccce4059563e620d25aed60274e05d31fe6375b1f31a3486033aa39ea5e82fd94afcfa32f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- PR title naming convention:
'[Issue type] Brief summary of issue suitable for changelog or copy/paste issue title',
where Issue type = bug, feature, spike, CU (code upkeep), etc.-->

<!-- Preferred branch naming convention:
'[Issue type]/[Issue #]-[Your name]-[Summary of issue]',
where Issue type = bug, feature, spike, CU (code upkeep), etc.-->

<!-- Update w/ ticket number to cross-repo link PR and ticket -->
Feature: **[Ticket 491](https://github.com/department-of-veterans-affairs/va-mobile-library/issues/491)**
Bug: **[Ticket 4514](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4514)**
Also related: **[Ticket 4174](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4174)**

## Description of Change
<!-- Describe the change and context with which it was made beyond ACs unless straightforward.
Consider:
 - What is relevant to code reviewer(s) and not in the ticket?
 - What context may be relevant to a future dev or you in 6 months about this PR?
 - Did the course of work lead to notable dead ends? If so, why didn't they pan out?
 - Did the change add new dependencies? Why?
 - Were there important sources to link? Examples: an open bug with a dependency project, an article of someone else solving the same problem that was partially or wholly copied, external documentation relevant to solution
 -->
Updated the internals for the Segmented control button to native via React Native instead of using the `styled-components` 3rd party library.

Also fixed the bug added by #625 where VoiceOver reads "selected" twice.

Details:
- Removed the `styled-components` dependency and corresponding `jest-styled-components` dependency
- Removed custom accessibility handling added by #625 
   - Also removed associated translations that are no longer used
- Design updates [to match Figma](https://www.figma.com/design/Zzt8z60hCtdEzXx2GFWghH/branch/vzQ2rqkg0F5rHDxPmFLHFL/VA-Mobile---Component-Library?node-id=211-282&t=eSFbPf6lU2jxyRNz-0) per #491:
   - Adjusted border radii (container and segment) from 8 to 6 pixels
   - Removed elevation property--elevation was Android only, slightly cleaner without it (no slight shading around selected segment)
      - Updated unit tests to remove checking elevation
- Pulled Segment into being a component nested within the Segmented control built using React Native
   - Moved `accessibilityState` prop to `aria-selected`--same functionality, but simpler and using the more web-like implementation
   - In shifting from `styled-components` to Pressable, some props moved to being style props
   - `key` prop moved up a level to the Segmented control mapping

#### Testing Packages
<!-- List or range of alpha/beta packages published in association with this PR, if any -->
- [0.34.1-alpha.0](https://www.npmjs.com/package/@department-of-veterans-affairs/mobile-component-library/v/0.34.1-alpha.0)

### Screenshots/Video
<!-- Add screenshots or video as needed; before/after recommended if appropriate. 
Convenience side-by-side formatting:
Before/after: <img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" />
Accordion before/after: <details><summary>Before/after</summary><img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" /></details>
-->
Before VoiceOver bugfix:

https://github.com/user-attachments/assets/51bf0869-2214-43f5-8429-af3d37d1c115

After VoiceOver bugfix:

https://github.com/user-attachments/assets/cc59d856-5340-438b-8452-5b71d713091c

## Testing
<!-- Describe testing conducted to validate changes.
Consider highlighting:
- What testing was not explicitly done and may be relevant for QA? 
- Edge cases validated
- Special situations that could not be tested
- Any testing performed in a consuming app -->
Validated Segmented control continues working as expected including accessibility. Checked side-by-side with VAHB (prior `styled-components` implementation) to verify no visual or functional changes occurred except the intended ones.

Created alpha build and verified Segmented control worked as expected with changes in VAHB as well.

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->
- [x] Tested on Web

## PR Checklist
Code reviewer validation:
- General
	- [x] PR is linked to ticket(s)
	- [x] PR has `changelog` label applied if it's to be included in the changelog
	- [x] Acceptance criteria: 
		- All satisfied _or_
		- Documented reason for not being performed _or_
		- Split to separate ticket and ticket is linked by relevant AC(s)
	- [x] Above PR sections adequately filled out
	- [x] If any breaking changes, in accordance with the [pre-1.0.0 versioning guidelines](https://github.com/department-of-veterans-affairs/va-mobile-library#versioning-policy): a CU ticket has been created for the VA Mobile App detailing necessary adjustments with the package version that will be published by this ticket
- Code
	- [x] Tests are included if appropriate (or split to separate ticket)
	- [x] New functions have proper TSDoc annotations

## Publish
<!-- Most changes entail a version increment; section can be removed for PRs exclusively within non-ship-relevant files (e.g. unit tests, Storybook stories) -->
If changes warrant a new version [per the versioning guidelines](https://github.com/department-of-veterans-affairs/va-mobile-library/blob/main/documentation/versioning.md) and the PR is approved and ready to merge:
- [x] Merge `main` into branch
- [x] Merge branch to `main`
- [x] Verify that [Check Component Integrations](https://github.com/department-of-veterans-affairs/va-mobile-library/actions/workflows/check-component-integrations.yml) workflow ran successfully
- [x] [Publish new version](https://github.com/department-of-veterans-affairs/va-mobile-library/actions/workflows/publish.yml) after merging
